### PR TITLE
Upgrade to scalafix v0.4.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -69,14 +69,14 @@ lazy val `sbt-rewrites` = project
   .settings(publishSettings, buildSettings, commonSettings)
   .settings(
     scalacOptions in Compile := compilerOptions,
-    crossScalaVersions := Seq("2.11.9", "2.12.1"),
+    crossScalaVersions := Seq("2.11.11", "2.12.2"),
     // Using 2.11.x until scalafix publishes 2.12 artifacts
     scalaVersion := crossScalaVersions.value.head,
     libraryDependencies ++= Vector(
       "com.github.pathikrit" %% "better-files" % "2.17.1",
       "io.get-coursier" %% "coursier" % "1.0.0-M15-5",
       "io.get-coursier" %% "coursier-cache" % "1.0.0-M15-5",
-      "ch.epfl.scala" % "scalafix-cli" % "0.3.3+18-3f58c785" cross CrossVersion.full,
+      "ch.epfl.scala" % "scalafix-cli" % "0.4.2" cross CrossVersion.full,
       "org.scalatest" %% "scalatest" % "3.0.0" % "test"
     ),
     assemblyJarName in assembly :=

--- a/build.sbt
+++ b/build.sbt
@@ -69,14 +69,14 @@ lazy val `sbt-rewrites` = project
   .settings(publishSettings, buildSettings, commonSettings)
   .settings(
     scalacOptions in Compile := compilerOptions,
-    crossScalaVersions := Seq("2.11.11", "2.12.2"),
+    crossScalaVersions := Seq("2.11.9", "2.12.1"),
     // Using 2.11.x until scalafix publishes 2.12 artifacts
     scalaVersion := crossScalaVersions.value.head,
     libraryDependencies ++= Vector(
       "com.github.pathikrit" %% "better-files" % "2.17.1",
       "io.get-coursier" %% "coursier" % "1.0.0-M15-5",
       "io.get-coursier" %% "coursier-cache" % "1.0.0-M15-5",
-      "ch.epfl.scala" % "scalafix-cli" % "0.4.2" cross CrossVersion.full,
+      "ch.epfl.scala" % "scalafix-cli" % "0.3.3+18-3f58c785" cross CrossVersion.full,
       "org.scalatest" %% "scalatest" % "3.0.0" % "test"
     ),
     assemblyJarName in assembly :=

--- a/scalafix/build.sbt
+++ b/scalafix/build.sbt
@@ -1,0 +1,52 @@
+// Use a scala version supported by scalafix.
+scalaVersion in ThisBuild := org.scalameta.BuildInfo.supportedScalaVersions.last
+lazy val root = project.in(file(".")).aggregate(rewrites, input, output, tests)
+
+lazy val sharedSettings = Def.settings(
+  organization := "ch.epfl.scala",
+  resolvers += Resolver.bintrayRepo("scalameta", "maven")
+)
+
+lazy val rewrites = project.settings(
+  sharedSettings,
+  libraryDependencies ++= Seq(
+    "org.scalameta" %% "sbthost-runtime" % "0.1.0-RC3",
+    "ch.epfl.scala" %% "scalafix-core" % "0.4.2"
+  )
+)
+
+lazy val input = project.settings(
+  sharedSettings,
+  scalacOptions += "-Xplugin-require:sbthost",
+  scalaVersion := "2.10.6",
+  sbtPlugin := true,
+  scalacOptions += s"-P:sbthost:sourceroot:${sourceDirectory.in(Compile).value}",
+  addCompilerPlugin(
+    "org.scalameta" % "sbthost-nsc" % "0.1.0-RC3" cross CrossVersion.full)
+)
+
+lazy val output = project.settings(
+  scalaVersion := "2.10.6",
+  sbtPlugin := true
+)
+
+lazy val tests = project
+  .settings(
+    sharedSettings,
+    libraryDependencies ++= Seq(
+      "org.scalameta" %% "scalameta" % org.scalameta.BuildInfo.version,
+      "ch.epfl.scala" % "scalafix-testkit" % "0.4.2" % Test cross CrossVersion.full
+    ),
+    test.in(Test) := test.in(Test).dependsOn(compile.in(input, Compile)).value,
+    buildInfoPackage := "fix",
+    buildInfoKeys := Seq[BuildInfoKey](
+      "inputSourceroot" ->
+        sourceDirectory.in(input, Compile).value,
+      "outputSourceroot" ->
+        sourceDirectory.in(output, Compile).value,
+      "inputClassdirectory" ->
+        classDirectory.in(input, Compile).value
+    )
+  )
+  .dependsOn(rewrites)
+  .enablePlugins(BuildInfoPlugin)

--- a/scalafix/input/src/main/scala/fix/Sbtmigrationrewrites_v1.scala
+++ b/scalafix/input/src/main/scala/fix/Sbtmigrationrewrites_v1.scala
@@ -1,0 +1,17 @@
+/* ONLY
+rewrite = "scala:fix.Sbtmigrationrewrites_v1"
+ */
+package fix
+
+import sbt._, Keys._
+
+object Sbtmigrationrewrites_v1_Test {
+
+  lazy val target = taskKey[Seq[File]]("Target to be reassigned.")
+  lazy val seed = taskKey[Seq[File]]("Seed.")
+
+  target <++= Def.task {
+    println("Executing task.")
+    (seed).value
+  }
+}

--- a/scalafix/output/src/main/scala/fix/Sbtmigrationrewrites_v1.scala
+++ b/scalafix/output/src/main/scala/fix/Sbtmigrationrewrites_v1.scala
@@ -1,0 +1,14 @@
+package fix
+
+import sbt._, Keys._
+
+object Sbtmigrationrewrites_v1_Test {
+
+  lazy val target = taskKey[Seq[File]]("Target to be reassigned.")
+  lazy val seed = taskKey[Seq[File]]("Seed.")
+
+  target ++= (Def.task {
+    println("Executing task.")
+    (seed).value
+  }).value
+}

--- a/scalafix/project/build.properties
+++ b/scalafix/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.15

--- a/scalafix/project/plugins.sbt
+++ b/scalafix/project/plugins.sbt
@@ -1,0 +1,3 @@
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.4.2")
+addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-RC3")
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.6.1")

--- a/scalafix/readme.md
+++ b/scalafix/readme.md
@@ -1,0 +1,7 @@
+# Scalafix rewrites for sbt-migration-rewrites
+
+To develop rewrite:
+```
+sbt ~tests/test
+# edit rewrites/src/main/scala/fix/Sbtmigrationrewrites_v1.scala
+```

--- a/scalafix/rewrites/src/main/scala/fix/Sbtmigrationrewrites_v1.scala
+++ b/scalafix/rewrites/src/main/scala/fix/Sbtmigrationrewrites_v1.scala
@@ -1,0 +1,137 @@
+package fix
+
+import scala.collection.immutable.Seq
+import scala.meta._
+import scala.meta._
+import scala.meta.sbthost.Sbthost
+import scala.meta.tokens.Token.LeftParen
+import scala.meta.tokens.Token.RightParen
+import scalafix._
+
+case class Sbtmigrationrewrites_v1(brokenMirror: Mirror)
+    extends SemanticRewrite(Sbthost.patchMirror(brokenMirror)) {
+  val mirror = ImplicitMirror
+  def rewrite(ctx: RewriteCtx): Patch = {
+    ctx.reporter.info(mirror.database.toString())
+    ctx.reporter.info(ctx.tree.syntax)
+    ctx.reporter.info(ctx.tree.structure)
+    SbtOneZeroMigration(mirror, ctx).rewrite.asPatch
+  }
+}
+
+/**
+  * Migrates code from sbt 0.13.x to sbt 1.0.x.
+  *
+  */
+case class SbtOneZeroMigration(mirror: Mirror, ctx: RewriteCtx) {
+  sealed abstract class SbtOperator {
+    val operator: String
+    val newOperator: String
+
+    object SbtSelectors {
+      val value = ".value"
+      val taskValue = ".taskValue"
+      // val evaluated = ".evaluated"
+    }
+
+    object SpecialCases {
+//      val ctx: Interpreted = sbtContext.interpretContext
+      val keyOfTasks: Set[String] = Set.empty
+      val inputKeys: Set[String] = Set.empty
+    }
+
+    def unapply(tree: Term): Option[(Term, Token, Term.Arg)] = tree match {
+      case Term.ApplyInfix(lhs, o @ Term.Name(`operator`), _, Seq(rhs)) =>
+        Some((lhs, o.tokens.head, rhs))
+      case Term.Apply(Term.Select(lhs, o @ Term.Name(`operator`)), Seq(rhs)) =>
+        Some((lhs, o.tokens.head, rhs))
+      case Term.Apply(
+          Term.ApplyType(Term.Select(lhs, o @ Term.Name(`operator`)), _),
+          Seq(rhs)) =>
+        Some((lhs, o.tokens.head, rhs))
+      case _ =>
+        None
+    }
+
+    private def wrapInParenthesis(tokens: Tokens): List[Patch] = {
+      List(
+        ctx.addLeft(tokens.head, "("),
+        ctx.addRight(tokens.last, ")")
+      )
+    }
+
+    private def isParensWrapped(tokens: Tokens): Boolean = {
+      tokens.head.isInstanceOf[LeftParen] &&
+      tokens.last.isInstanceOf[RightParen]
+    }
+
+    private def existKeys(lhs: Term, keyNames: Set[String]): Boolean = {
+      val singleNames = lhs match {
+        case tname @ Term.Name(name) if keyNames.contains(name) => tname :: Nil
+        case _ => Nil
+      }
+      val scopedNames = lhs.collect {
+        case Term.Select(Term.Name(name), Term.Name("in"))
+            if keyNames.contains(name) =>
+          name
+        case Term.ApplyInfix(Term.Name(name), Term.Name("in"), _, _)
+            if keyNames.contains(name) =>
+          name
+      }
+      (singleNames ++ scopedNames).nonEmpty
+    }
+
+    def rewriteDslOperator(lhs: Term,
+                           opToken: Token,
+                           rhs: Term.Arg): List[Patch] = {
+      val wrapExpression = rhs match {
+        case arg @ Term.Apply(_, Seq(_: Term.Block))
+            if !isParensWrapped(arg.tokens) =>
+          wrapInParenthesis(arg.tokens)
+        case arg: Term.ApplyInfix if !isParensWrapped(arg.tokens) =>
+          wrapInParenthesis(arg.tokens)
+        case _ => Nil
+      }
+
+      val removeOperator = ctx.removeToken(opToken)
+      val addNewOperator = ctx.addLeft(opToken, newOperator)
+      val rewriteRhs = {
+        val requiresTaskValue = existKeys(lhs, SpecialCases.keyOfTasks)
+        // val requiresEvaluated = existKeys(lhs, SpecialCases.inputKeys)
+        val newSelector =
+          if (requiresTaskValue) SbtSelectors.taskValue
+          // else if (requiresEvaluated) SbtSelectors.evaluated
+          else SbtSelectors.value
+        ctx.addRight(rhs.tokens.last, newSelector)
+      }
+
+      (removeOperator :: addNewOperator :: wrapExpression) ++ Seq(rewriteRhs)
+    }
+  }
+
+  object `<<=` extends SbtOperator {
+    override final val operator = "<<="
+    override final val newOperator: String = ":="
+  }
+
+  object `<+=` extends SbtOperator {
+    override final val operator = "<+="
+    override final val newOperator: String = "+="
+  }
+
+  object `<++=` extends SbtOperator {
+    override final val operator = "<++="
+    override final val newOperator: String = "++="
+  }
+
+  def rewrite: Seq[Patch] = {
+    ctx.tree.collect {
+      case `<<=`(lhs: Term, opToken: Token, rhs: Term.Arg) =>
+        `<<=`.rewriteDslOperator(lhs, opToken, rhs)
+      case `<+=`(lhs: Term, opToken: Token, rhs: Term.Arg) =>
+        `<+=`.rewriteDslOperator(lhs, opToken, rhs)
+      case `<++=`(lhs: Term, opToken: Token, rhs: Term.Arg) =>
+        `<++=`.rewriteDslOperator(lhs, opToken, rhs)
+    }.flatten
+  }
+}

--- a/scalafix/tests/src/test/scala/fix/Sbtmigrationrewrites_Tests.scala
+++ b/scalafix/tests/src/test/scala/fix/Sbtmigrationrewrites_Tests.scala
@@ -1,0 +1,13 @@
+package fix
+
+import scala.meta._
+import scalafix.testkit._
+
+class Sbtmigrationrewrites_Tests
+    extends SemanticRewriteSuite(
+      Database.load(Classpath(AbsolutePath(BuildInfo.inputClassdirectory))),
+      AbsolutePath(BuildInfo.inputSourceroot),
+      Seq(AbsolutePath(BuildInfo.outputSourceroot))
+    ) {
+  runAllTests()
+}


### PR DESCRIPTION
- scalacenter/scalafix.g8 directory layout, allowing users to run
  `sbt scalacenter/sbt-migration-rewrites/v1.0` with scalafix-cli.
- sbthost for semantic rewrites for 2.10.
- Test suite using scalafix-testkit.